### PR TITLE
Fix three code bugs

### DIFF
--- a/apps/papra-server/src/modules/documents/documents.repository.ts
+++ b/apps/papra-server/src/modules/documents/documents.repository.ts
@@ -2,7 +2,7 @@ import type { Database } from '../app/database/database.types';
 import type { DbInsertableDocument } from './documents.types';
 import { injectArguments, safely } from '@corentinth/chisels';
 import { subDays } from 'date-fns';
-import { and, count, desc, eq, getTableColumns, lt, sql, sum } from 'drizzle-orm';
+import { and, count, countDistinct, desc, eq, getTableColumns, inArray, lt, sql, sum } from 'drizzle-orm';
 import { omit } from 'lodash-es';
 import { createOrganizationNotFoundError } from '../organizations/organizations.errors';
 import { isUniqueConstraintError } from '../shared/db/constraints.models';
@@ -79,17 +79,39 @@ async function saveOrganizationDocument({ db, ...documentToInsert }: { db: Datab
 }
 
 async function getOrganizationDocumentsCount({ organizationId, filters, db }: { organizationId: string; filters?: { tags?: string[] }; db: Database }) {
+  if (filters?.tags && filters.tags.length > 0) {
+    const [record] = await db
+      .select({
+        documentsCount: countDistinct(documentsTable.id),
+      })
+      .from(documentsTable)
+      .innerJoin(documentsTagsTable, eq(documentsTable.id, documentsTagsTable.documentId))
+      .where(
+        and(
+          eq(documentsTable.organizationId, organizationId),
+          eq(documentsTable.isDeleted, false),
+          inArray(documentsTagsTable.tagId, filters.tags),
+        ),
+      );
+
+    if (isNil(record)) {
+      throw createOrganizationNotFoundError();
+    }
+
+    const { documentsCount } = record;
+
+    return { documentsCount };
+  }
+
   const [record] = await db
     .select({
       documentsCount: count(documentsTable.id),
     })
     .from(documentsTable)
-    .leftJoin(documentsTagsTable, eq(documentsTable.id, documentsTagsTable.documentId))
     .where(
       and(
         eq(documentsTable.organizationId, organizationId),
         eq(documentsTable.isDeleted, false),
-        ...(filters?.tags ? filters.tags.map(tag => eq(documentsTagsTable.tagId, tag)) : []),
       ),
     );
 
@@ -149,7 +171,7 @@ async function getOrganizationDocuments({
       and(
         eq(documentsTable.organizationId, organizationId),
         eq(documentsTable.isDeleted, false),
-        ...(filters?.tags ? filters.tags.map(tag => eq(documentsTagsTable.tagId, tag)) : []),
+        ...(filters?.tags ? [inArray(documentsTagsTable.tagId, filters.tags)] : []),
       ),
     );
 
@@ -224,13 +246,15 @@ async function getDocumentById({ documentId, organizationId, db }: { documentId:
     return { document: undefined };
   }
 
-  const tags = await db
+  const rawTags = await db
     .select({
       ...getTableColumns(tagsTable),
     })
     .from(documentsTagsTable)
     .leftJoin(tagsTable, eq(tagsTable.id, documentsTagsTable.tagId))
     .where(eq(documentsTagsTable.documentId, documentId));
+
+  const tags = rawTags.filter(tag => !isNil(tag.id));
 
   return {
     document: {

--- a/apps/papra-server/src/modules/documents/documents.usecases.ts
+++ b/apps/papra-server/src/modules/documents/documents.usecases.ts
@@ -263,7 +263,7 @@ async function createNewDocument({
     logger.error({ error }, 'Error while creating document');
 
     // If the document is not saved, delete the file from the storage
-    await documentsStorageService.deleteFile({ storageKey: originalDocumentStorageKey });
+    await documentsStorageService.deleteFile({ storageKey });
 
     logger.error({ error }, 'Stored document file deleted because of error');
 


### PR DESCRIPTION
Corrects tag filtering and counting, filters out null tags, and ensures proper file deletion on document creation failure.

The previous tag filtering for document counts and lists incorrectly used ANDed single-tag conditions and overcounted due to joins; this is fixed with `inArray` and `countDistinct`. `getDocumentById` could return null tags from `LEFT JOIN`s, now filtered. Finally, file cleanup on insert failure now uses the actual `storageKey` returned by the storage service, preventing orphaned files.

---
<a href="https://cursor.com/background-agent?bcId=bc-10796e43-7411-412f-817a-6e04778aaf61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10796e43-7411-412f-817a-6e04778aaf61">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

