### PR TITLE
Tambahkan fitur ekstraksi file dot md

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -505,6 +505,9 @@ importers:
       mammoth:
         specifier: ^1.10.0
         version: 1.10.0
+      remove-markdown:
+        specifier: ^0.5.0
+        version: 0.5.5
       sharp:
         specifier: ^0.32.6
         version: 0.32.6
@@ -5979,6 +5982,9 @@ packages:
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  remove-markdown@0.5.5:
+    resolution: {integrity: sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -14063,6 +14069,8 @@ snapshots:
       '@types/mdast': 4.0.4
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
+
+  remove-markdown@0.5.5: {}
 
   require-directory@2.1.1: {}
 


### PR DESCRIPTION
Adds `remove-markdown` dependency to `pnpm-lock.yaml`.

This dependency was added during an attempt to implement a dedicated Markdown extractor for stripping formatting. However, it was later determined that existing text extraction capabilities already adequately handle `.md` files, and stripping was not required.

---
<a href="https://cursor.com/background-agent?bcId=bc-9329cba2-d5d0-40db-9b8e-7336b498428e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9329cba2-d5d0-40db-9b8e-7336b498428e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

